### PR TITLE
Only define ROOTPATH if not defined already

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The instructions for employment of this class are on [this page](https://bmlt.ap
 CHANGELIST
 ----------
 
+***Version 3.9.8* ** *- December 7, 2018*
+- Only define ROOTPATH if not defined already.
+
 ***Version 3.9.7* ** *- December 5, 2018*
 
 - Added the "NERNA" theme.

--- a/bmlt-cms-satellite-plugin.php
+++ b/bmlt-cms-satellite-plugin.php
@@ -3,7 +3,7 @@
 *   \file   bmlt-cms-satellite-plugin.php                                                   *
 *                                                                                           *
 *   \brief  This is a generic CMS plugin class for a BMLT satellite client.                 *
-*   \version 3.9.7                                                                          *
+*   \version 3.9.8                                                                          *
 *                                                                                           *
 *   This file is part of the BMLT Common Satellite Base Class Project. The project GitHub   *
 *   page is available here: https://github.com/MAGSHARE/BMLT-Common-CMS-Plugin-Class        *
@@ -29,7 +29,9 @@
 // define ( '_DEBUG_MODE_', 1 ); //Uncomment for easier JavaScript debugging.
 
 // Include the satellite driver class.
-define('ROOTPATH', __DIR__);
+if (!defined('ROOTPATH')) {
+    define('ROOTPATH', __DIR__);
+}
 require_once ( ROOTPATH .'/vendor/bmlt/bmlt-satellite-driver/bmlt_satellite_controller.class.php' );
 
 global $g_lang_keys;


### PR DESCRIPTION
this will fix the ROOTPATH already defined warnings.