### PR TITLE
Fix for bmlt_changes, function should not be declared static

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The instructions for employment of this class are on [this page](https://bmlt.ap
 CHANGELIST
 ----------
 
-***Version 4.0.0* ** *- UNRELEASED*
+***Version 3.9.10* ** *- UNRELEASED*
 - Fix for the BMLT_CHANGES shortcode.
 
 ***Version 3.9.9* ** *- December 14, 2018*

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ CHANGELIST
 
 ***Version 3.9.10* ** *- UNRELEASED*
 - Fix for the BMLT_CHANGES shortcode.
+- WML 1.1 fix for BMLT_MOBILE shortcode.
 
 ***Version 3.9.9* ** *- December 14, 2018*
 - Form javascript URLs correctly when behind a firewall or load balancer.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The instructions for employment of this class are on [this page](https://bmlt.ap
 CHANGELIST
 ----------
 
+***Version 4.0.0* ** *- UNRELEASED*
+- Fix for the BMLT_CHANGES shortcode.
+
 ***Version 3.9.9* ** *- December 14, 2018*
 - Form javascript URLs correctly when behind a firewall or load balancer.
 

--- a/bmlt-cms-satellite-plugin.php
+++ b/bmlt-cms-satellite-plugin.php
@@ -2800,7 +2800,7 @@ abstract class BMLTPlugin
                         $the_new_content = '<div class="bmlt_change_record_div">';
                         foreach ( $changes as $change )
                             {
-                            $the_new_content .= self::setup_one_change ( $change, $single_uri );
+                            $the_new_content .= $this->setup_one_change ( $change, $single_uri );
                             }
                         
                         $the_new_content .= '</div>';

--- a/bmlt-cms-satellite-plugin.php
+++ b/bmlt-cms-satellite-plugin.php
@@ -3,7 +3,7 @@
 *   \file   bmlt-cms-satellite-plugin.php                                                   *
 *                                                                                           *
 *   \brief  This is a generic CMS plugin class for a BMLT satellite client.                 *
-*   \version 3.9.9                                                                          *
+*   \version 3.9.10                                                                          *
 *                                                                                           *
 *   This file is part of the BMLT Common Satellite Base Class Project. The project GitHub   *
 *   page is available here: https://github.com/MAGSHARE/BMLT-Common-CMS-Plugin-Class        *

--- a/bmlt-cms-satellite-plugin.php
+++ b/bmlt-cms-satellite-plugin.php
@@ -2818,7 +2818,7 @@ abstract class BMLTPlugin
     *                                                                                       *
     *   \returns A string. The DOCTYPE to be displayed.                                     *
     ****************************************************************************************/
-    static function setup_one_change (  $in_change_array,       ///< One change record
+    function setup_one_change (  $in_change_array,       ///< One change record
                                         $in_single_uri = null   ///< If there was a specific single meeting URI, we pass it in here.
                                         )
         {


### PR DESCRIPTION
the bmlt_changes shortcode hasn't worked as long as ive been using bmlt, this fixes it. 
https://bmlt.app/satellites/cms-plugins/shortcodes/#bmlt-changes

**working examples**

[WordPress](https://sca.charlestonna.org/changesword/)
[BMLT Basic](https://nnerna.charlestonna.org/bmlt-basic/changes.php)
[Drupal](https://bmlt-drupal.charlestonna.org/node/4)
