### PR TITLE
hopefully final fix for including the satellite-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ CHANGELIST
 ***Version 3.9.10* ** *- UNRELEASED*
 - Fix for the BMLT_CHANGES shortcode.
 - WML 1.1 fix for BMLT_MOBILE shortcode.
+- ROOTPATH must ALWAYS be defined, but if its not we must account for that properly.
 
 ***Version 3.9.9* ** *- December 14, 2018*
 - Form javascript URLs correctly when behind a firewall or load balancer.

--- a/bmlt-cms-satellite-plugin.php
+++ b/bmlt-cms-satellite-plugin.php
@@ -30,9 +30,10 @@
 
 // Include the satellite driver class.
 if (!defined('ROOTPATH')) {
-    define('ROOTPATH', __DIR__);
+    require_once ( __DIR__.'/../bmlt-satellite-driver/bmlt_satellite_controller.class.php' );
+} else {
+    require_once ( ROOTPATH .'/vendor/bmlt/bmlt-satellite-driver/bmlt_satellite_controller.class.php' );
 }
-require_once ( ROOTPATH .'/vendor/bmlt/bmlt-satellite-driver/bmlt_satellite_controller.class.php' );
 
 global $g_lang_keys;
 global $g_my_languages;

--- a/bmlt-cms-satellite-plugin.php
+++ b/bmlt-cms-satellite-plugin.php
@@ -2367,7 +2367,7 @@ abstract class BMLTPlugin
                     }
                 
                 // See if there is an options ID in the parameter list.
-                if ( (is_array ( count ( $param_array ) ) && (count ( $param_array ) > 1)) || (intval ( $param_array[0] ) && preg_match ( '/^\d+$/', $param_array[0] )) )
+                if ( (is_array ( $param_array ) && (count ( $param_array ) > 1)) || (intval ( $param_array[0] ) && preg_match ( '/^\d+$/', $param_array[0] )) )
                     {
                     $options_id = intval ( $param_array[0] );
                     if ( count ( $param_array ) == 1 )


### PR DESCRIPTION
basically this always needs to be defined for the satellites, but if for some crazy reason ha its not, we still need to load the satellite-driver properly. one clear case this is needed is for unit tests.
referencing issue #10 